### PR TITLE
Feat/llm service logic

### DIFF
--- a/backend/services/common/health_service.py
+++ b/backend/services/common/health_service.py
@@ -18,7 +18,7 @@ from schemas.llm import (
 from services.ocr.body_type_service import BodyTypeService
 from services.llm.llm_service import LLMService
 from typing import Optional, Dict, Any
-
+from services.llm.parse_utils import split_analysis_response
 
 class HealthService:
     """건강 기록 관련 비즈니스 로직"""
@@ -178,7 +178,7 @@ class HealthService:
         
         if existing_report:
             # 기존 리포트도 summary와 content로 분리하여 반환
-            from services.llm.parse_utils import split_analysis_response
+
             
             response = AnalysisReportResponse.model_validate(existing_report)
             parsed = split_analysis_response(existing_report.llm_output)
@@ -224,10 +224,17 @@ class HealthService:
             embedding_1536 = None
             embedding_1024 = None
 
+        # 4-1. LLM 출력 결과를 요약과 전문으로 분리 (DB 저장용)
+        # DB에는 요약만 저장하고, 프론트엔드에서는 필요 시 전문을 다시 생성하도록 함
+        parsed = split_analysis_response(llm_output)
+        summary_text = parsed["summary"]
+        content_text = parsed["content"]
+
+
         # 5. 분석 리포트 저장
         report_data = AnalysisReportCreate(
             record_id=record_id,
-            llm_output=llm_output,
+            llm_output=summary_text,                              # llm_output을 넣기 전에 요약과 전문으로 분리해서 요약만 저장하기
             model_version=self.llm_service.model_version,
             analysis_type="status_analysis",
             thread_id=thread_id,
@@ -242,12 +249,9 @@ class HealthService:
         response = AnalysisReportResponse.model_validate(analysis_report)
         response.thread_id = thread_id
         
-        # LLM1 출력 결과를 요약과 전문으로 분리 (프론트엔드 표시용)
         # 프론트엔드에서 요약만 먼저 보여주고, 전문은 접었다가 펼칠 수 있도록 함
-        from services.llm.parse_utils import split_analysis_response
-        parsed = split_analysis_response(llm_output)
-        response.summary = parsed["summary"]
-        response.content = parsed["content"]
+        response.summary = summary_text
+        response.content = content_text
         
         return response
 

--- a/backend/services/llm/weekly_plan_service.py
+++ b/backend/services/llm/weekly_plan_service.py
@@ -47,7 +47,7 @@ class WeeklyPlanService:
         
         # 트리거 2: 새로운 인바디 측정
         latest_inbody = HealthRecordRepository.get_latest(db, user_id)
-        if latest_inbody and latest_inbody.measured_at.date() >= latest_plan.start_date:
+        if latest_inbody and latest_inbody.measured_at > latest_plan.created_at:
             return True
     
         return False

--- a/backend/services/llm/weekly_plan_service.py
+++ b/backend/services/llm/weekly_plan_service.py
@@ -10,6 +10,7 @@ from typing import Dict, Any
 from services.llm.llm_service import LLMService
 from services.common.health_service import HealthService
 from repositories.llm.weekly_plan_repository import WeeklyPlanRepository
+from repositories.common.health_record_repository import HealthRecordRepository
 from schemas.llm import WeeklyPlanCreate, GoalPlanRequest, GoalPlanInput
 
 # 가장 최신 주간 계획이 있는지 없는지 확인
@@ -32,7 +33,7 @@ class WeeklyPlanService:
         self, 
         db: Session, 
         user_id: int, 
-        latest_plan: WeeklyPlan | None
+        latest_plan # 타입 힌트 없음.
     ) -> bool:
         """새 주간 계획 생성이 필요한지 판단"""
         if not latest_plan:
@@ -45,8 +46,8 @@ class WeeklyPlanService:
             return True
         
         # 트리거 2: 새로운 인바디 측정
-        latest_inbody = HealthService.get_latest_inbody(db, user_id)
-        if latest_inbody and latest_inbody.measured_at >= latest_plan.start_date:
+        latest_inbody = HealthRecordRepository.get_latest(db, user_id)
+        if latest_inbody and latest_inbody.measured_at.date() >= latest_plan.start_date:
             return True
     
         return False
@@ -63,7 +64,7 @@ class WeeklyPlanService:
         """
         
         # Early return: 기존 계획 재사용
-        latest_plan = WeeklyPlanRepository.get_latest_plan(db, user_id)
+        latest_plan = WeeklyPlanRepository.get_latest(db, user_id)
         if not self._should_create_new_plan(db, user_id, latest_plan):
             return latest_plan
 


### PR DESCRIPTION
- LLM1 (인바디 결과 분석) 의 출력물을 summary만 DB의 llm_output 칼럼에 저장되도록 수정
- LLM2 (주간 계획서 작성)에서 챗봇으로 진입할 때, 주간 계획서를 재작성할지에 대한 판단 로직 추가
   - 기존 주간 계획서가 만료 되었거나,
   - 새로운 인바디 기록이 들어왔을 경우에만
   - 주간 계획서 재작성.
   - 그렇지 않을 시, 기존 주간 계획서를 사용자에게 반환

   - 기존: 주간 계획서 챗봇에 들어가면 무조건 주간 계획서 재작성
   - 변경: 주간 계획서 챗봇에 들어가면, 조건을 확인하고 조건이 충족되었을 때에만 주간 계획서 재작성, 아닐 시 기존 주간 계획서 조회