### PR TITLE
feat: LLM2대화에서 기존 주간계획서를 기억하는 기능 추가

### DIFF
--- a/backend/services/llm/llm_service.py
+++ b/backend/services/llm/llm_service.py
@@ -206,7 +206,8 @@ class LLMService:
     async def chat_with_plan(
         self,
         thread_id: str,
-        user_message: str
+        user_message: str,
+        existing_plan: Optional[str] = None
     ) -> str:
         """
         LLM2 휴먼 피드백 (Q&A) 처리: 주간 계획 수정 및 질의응답
@@ -258,9 +259,13 @@ class LLMService:
         input_payload = {
             "messages": [("human", clean_message)],
             # feedback_category를 업데이트하여 라우터가 올바른 경로를 타도록 함
-            "feedback_category": category 
+            "feedback_category": category,
+            "existing_plan": existing_plan
         }
         
+        print(f"--- [DEBUG] llm_service: existing_plan 전달 여부: {bool(existing_plan)} ---")
+        if existing_plan:
+            print(f"--- [DEBUG] llm_service: existing_plan preview: {existing_plan[:100]}... ---")
         print(f"--- [DEBUG] Invoking weekly_plan_agent with payload: {input_payload}")
 
         # LangGraph 실행 (이전 상태에서 이어서 실행)

--- a/backend/services/llm/weekly_plan_service.py
+++ b/backend/services/llm/weekly_plan_service.py
@@ -138,8 +138,17 @@ class WeeklyPlanService :
         """
         주간 계획에 대한 수정 요청/질의응답 (DB 저장 포함)
         """
+        # 0. 기존 계획 내용 가져오기 (새 세션 맥락 제공용)
+        plan = WeeklyPlanRepository.get_by_id(db, plan_id)
+        existing_plan_content = None
+        if plan and plan.plan_data:
+            existing_plan_content = plan.plan_data.get("content")
+            print(f"--- [DEBUG] weekly_plan_service: 기존 계획 가져오기 성공 (length: {len(existing_plan_content) if existing_plan_content else 0}) ---")
+        else:
+            print(f"--- [DEBUG] weekly_plan_service: 기존 계획 없음 (plan={plan}, plan_data={plan.plan_data if plan else None}) ---")
+        
         # 1. LLM Service 호출 (LangGraph 실행)
-        response_text = await self.llm_service.chat_with_plan(thread_id, message)
+        response_text = await self.llm_service.chat_with_plan(thread_id, message, existing_plan_content)
         
         # 2. 결과 DB 저장 (이력 추적)
         # LLMInteraction 저장


### PR DESCRIPTION
- 기존의 LLM2 에서는 페이지를 새로고침하고 나면, 기존의 주간 계획서와 관련해 대화를 진행할 때 LLM이 기존의 주간 계획서를 모르는 문제가 있음.
- 현재: 기존의 주간 계획서를 전달하는 기능을 추가함.