### PR TITLE
Test Beta 버전을 위한 병합 테스트 진행 및 오류 수정

### DIFF
--- a/backend/schemas/common.py
+++ b/backend/schemas/common.py
@@ -30,15 +30,15 @@ class EmailCheckRequest(BaseModel):
 class UserSignupRequest(UserCreate):
     """회원가입 요청 스키마 (확장)"""
     # 신체 정보
-    gender: str
-    age: int
-    height: float
+    gender: Optional[str] = "남성"
+    age: Optional[int] = None
+    height: Optional[float] = None
     # 인바디 데이터 (Step 2) - 선택 사항 (건너뛰기 가능할 수도 있음)
     inbodyData: Optional[Dict[str, Any]] = None
     inbodyImage: Optional[Any] = None # 이미지는 별도 처리하거나 URL로 받을 수 있음. 여기선 제외.
     # 목표 설정 (Step 3)
-    startWeight: float
-    targetWeight: float
+    startWeight: Optional[float] = None
+    targetWeight: Optional[float] = None
     goalType: str
     activityLevel: str
     preferredExercises: Optional[list[str]] = []

--- a/backend/services/llm/prompt_generator.py
+++ b/backend/services/llm/prompt_generator.py
@@ -31,10 +31,11 @@ def create_inbody_analysis_prompt(
     print(f"\n[DEBUG][PromptGenerator] create_inbody_analysis_prompt 호출")
     print(f"[DEBUG][PromptGenerator] prev_inbody_data is None: {prev_inbody_data is None}")
     print(f"[DEBUG][PromptGenerator] interval_days is None: {interval_days is None}")
-
+    # test를 위해서 interval_days를 10일로 설정  #fixme
+    interval_days = "10"
     # 이전 인바디 데이터 포맷팅
     prev_inbody_text = "없음"
-    if prev_inbody_data:
+    if prev_inbody_data and interval_days:
         print(f"[DEBUG][PromptGenerator] ✅ 이전 인바디 데이터로 텍스트 생성 중...")
         prev_inbody_text = f"""
 이전 인바디 데이터와 간격 {interval_days}일
@@ -71,7 +72,7 @@ def create_inbody_analysis_prompt(
         - 숫자/목표는 **굵게 강조**
         - 딱딱한 보고서 말투 금지 ("필요합니다" X)
         - 행동 중심
-        - 읽기 쉽게 미션/포인트 느낌
+        - 읽기 쉽게 미션/포인트 느
         - 문장 끝은 가끔 코치 한마디로 마무리
 
 
@@ -89,8 +90,12 @@ def create_inbody_analysis_prompt(
 
 
         ### [📊 이전 기록과의 변화]
-        (이전 기록 있으면 3~5줄 수치 비교 / 없으면 '이전 기록 없음')
-
+        이전 인바디 기록 정보: {prev_inbody_text}
+        - 이전 기록이 있으면 **3~5줄 이내**로 핵심 변화만 해석
+        - “이전보다 증가/감소”로 끝내지 말고
+        **이 변화가 의미하는 체성분 패턴**을 반드시 설명
+        - 이전 기록이 없으면:
+        → “이전 기록 없음” + 현재 상태가 **시작점으로서 어떤 의미인지** 설명
 
         ### [📈 개선사항 및 권장 행동]
         1. ...
@@ -128,10 +133,6 @@ def create_inbody_analysis_prompt(
         - 무례한 농담 금지
         - 유머는 "가볍고 긍정적인 동기부여" 수준만 허용
 
-        ---
-
-        이전 인바디 기록: {prev_inbody_text}
-
         """
 
 
@@ -148,9 +149,10 @@ def create_inbody_analysis_prompt(
     user_prompt_parts.append(f"- 체중: {measurements.체중관리.체중} kg")
 
 
-    # 인바디 이전 정보
-    user_prompt_parts.append("## 인바디 이전 정보")
-    user_prompt_parts.append(f"- 이전 인바디 기록: {prev_inbody_text}")
+    # 인바디 이전 정보 (데이터가 실제로 있을 때만 포함)
+    if prev_inbody_text != "없음":
+        user_prompt_parts.append("\n## ⚠️ 이전 인바디 기록과의 비교")
+        user_prompt_parts.append(prev_inbody_text)
 
 
     # 체성분


### PR DESCRIPTION
- LLM1에서 이전 비교 프롬프트를 LLM이 더 잘 인식할 수 있도록 프롬프트 수정
- 회원가입 시 목표의 시작 체중이 하드코딩 되어있는 오류 수정
- 기존: 목표의 시작 체중이 80.4로 하드코딩 되어있음
- 현재: 목표의 시작 체중은 OCR 인바디의 체중을 기반으로 고정되어있음.
           만약 OCR을 진행하지 않았다면, 임의로 시작 체중과 목표체중을 입력할 수 있음.
- 회원가입 시 OCR을 진행하지 않아도 OCR 인바디 신체기록이 입력되는 오류 수정
- 기존: 회원가입 시 OCR을 진행하지 않으면, 하드코딩되어있는 시작 체중이 인바디 신체기록으로 들어감
- 현재: 회원가입 시 OCR을 진행하지 않으면, 인바디 신체기록은 없음으로 처리됨.